### PR TITLE
Fix 404 oops tests

### DIFF
--- a/js/tests/PredicateTests.js
+++ b/js/tests/PredicateTests.js
@@ -54,7 +54,7 @@ const PredicateTests = {
         'when the predicate matches 404 for location and thrill level.',
         (assert) => {
           // ARRANGE
-          const expectedTitle = 'OOOPS...Something when wrong.';
+          const expectedTitle = 'OOOPS...Something went wrong.';
           const expectedSize = 3;
           const repo = new ActivityRepository(
               this.Constants.TEST_PREDICATE_RETURN_VALUE);

--- a/js/tests/ResultManagerTests.js
+++ b/js/tests/ResultManagerTests.js
@@ -76,15 +76,15 @@ const ResultManagerTests = {
           TestLib.Value.isEqual(
               assert,
               expectedResultA.title,
-              'OOOPS...Something when wrong.');
+              'OOOPS...Something went wrong.');
           TestLib.Value.isEqual(
               assert,
               expectedResultB.title,
-              'OOOPS...Something when wrong.');
+              'OOOPS...Something went wrong.');
           TestLib.Value.isEqual(
               assert,
               expectedResultC.title,
-              'OOOPS...Something when wrong.');
+              'OOOPS...Something went wrong.');
           TestLib.Value.isEqual(assert, expectedLength, actualLength);
 
           localStorage.removeItem(


### PR DESCRIPTION
- Updated the expected value on the tests.
- We previously changed the wording on the actual values but forgot to
  update the expected value on the tests.